### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,4 +696,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🌟 Stargazers
 
-[![Stargazers repo roster for @muhittincamdali/iOS-Enterprise-Deployment-Framework](https://starchart.cc/muhittincamdali/iOS-Enterprise-Deployment-Framework.svg)](https://github.com/muhittincamdali/iOS-Enterprise-Deployment-Framework/stargazers) 


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.